### PR TITLE
add ads block

### DIFF
--- a/blocks.json
+++ b/blocks.json
@@ -2,6 +2,7 @@
   "org": "@wpmedia",
   "useLocal": false,
   "blocks": [
+    "@wpmedia/ads-block",
     "@wpmedia/global-phrases-block",
     "@wpmedia/alert-bar-block",
     "@wpmedia/article-body-block",

--- a/blocks.json
+++ b/blocks.json
@@ -86,7 +86,7 @@
       "siteProperties": {
         "primaryLogo": "https://www.arcpublishing.com/pf/resources/svg/arc-logo.svg?d=21",
         "primaryLogoAlt": "Arc Publishing logo",
-        "dfpId": 0,
+        "dfpId": 701,
         "fontUrl": "https://fonts.google.com/specimen/Noto+Sans+JP?query=sans",
         "navColor": "light",
         "fallbackImage": "https://cloudfront-us-east-1.images.arcpublishing.com/arcthemestraining/6PKZES4FYJBB5GSRZO4WHAUXAY.png",


### PR DESCRIPTION
Since this release includes the Google Ad block, I'll want to test that we can install/use it as expected in the Arc Themes Training environment as part of smoke testing after the release is complete (repo herehttps://github.com/wapopartners/ARC-ThemesTraining-PageBuilder-Fusion/blob/master/blocks.json) – we'll just need to add it to the blocks.json file